### PR TITLE
SMD-368 Start position and bitrate icon fix

### DIFF
--- a/PlayKitReadMe.md
+++ b/PlayKitReadMe.md
@@ -505,7 +505,7 @@ Please note it is no longer required to pass the UIConfig parameter to PlayKit.
 If you have provided the Partner ID to the PlayKit already, you do not need to pass this with each media request:
 
 ``` Kotlin
-public fun loadMedia(serverUrl: String, entryID: String, ks: String? = null, title: String? = null, mediaType: AMGMediaType = AMGMediaType.VOD)
+public fun loadMedia(serverUrl: String, entryID: String, ks: String? = null, title: String? = null, mediaType: AMGMediaType = AMGMediaType.VOD, startPosition: Long = -1)
 ```
 for example:
 ``` Kotlin
@@ -514,7 +514,7 @@ playKit.loadMedia("https://mymediaserver.com", "0_myEntryID", "VALID_KS_PROVIDED
 
 Or with a Partner ID
 ``` Kotlin
-public fun loadMedia(serverUrl: String, partnerID: Int, entryID: String, ks: String? = null, title: String? = null, mediaType: AMGMediaType = AMGMediaType.VOD)
+public fun loadMedia(serverUrl: String, partnerID: Int, entryID: String, ks: String? = null, title: String? = null, mediaType: AMGMediaType = AMGMediaType.VOD, startPosition: Long = -1)
 ```
 for example:
 ``` Kotlin
@@ -598,6 +598,10 @@ PlayKit will atttempt to change bitrate to that value (or the closest one BELOW 
 # Change Log
 
 All notable changes to this project will be documented in this section.
+
+### 1.1.1
+- Added startPosition to loadMedia
+- Fixed bitrate selector icon when live
 
 ### 1.1.0
 - Improved bitrate selector UI

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Change Log:
 
 All notable changes to this project will be documented in this section.
 
+### 1.1.1 - PlayKit minor update
+
 ### 1.1.0 - Improved bitrate selector UI and Playkit updates
 
 ### 1.0.3 - PlayKit HLS casting update

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ plugins {
     id 'maven-publish'
 }
 // Versions of the library modules are matched (eg 1.0 core goes with 1.0 cloudmatrix) to prevent dependency issues
-ext.SDK_VERSION_CODE = 11
-ext.SDK_VERSION_NAME = "1.1.0"
+ext.SDK_VERSION_CODE = 12
+ext.SDK_VERSION_NAME = "1.1.1"
 
 publishing {
     publications {

--- a/streamamg-sdk-playkit/src/main/java/com/streamamg/amg_playkit/AMGPlayKit.kt
+++ b/streamamg-sdk-playkit/src/main/java/com/streamamg/amg_playkit/AMGPlayKit.kt
@@ -477,15 +477,15 @@ class AMGPlayKit : LinearLayout, AMGPlayerInterface {
 //        return false
 //    }
 
-    internal fun loadMedia(mediaConfig: MediaItem, mediaType: AMGMediaType = AMGMediaType.VOD, from: Long = 0, bitrate: FlavorAsset? = null) {
+    internal fun loadMedia(mediaConfig: MediaItem, mediaType: AMGMediaType = AMGMediaType.VOD, startPosition: Long = -1, bitrate: FlavorAsset? = null) {
         currentMediaItem = mediaConfig
         currentMediaType = mediaType
         if (player == null) {
             return
         }
 
-        if (from > 0) {
-            mediaConfig.mediaConfig.startPosition = from / 1000
+        if (startPosition >= 0) {
+            mediaConfig.mediaConfig.startPosition = startPosition / 1000
         }
 
         updateAnalyticsPlugin(mediaConfig.entryID)
@@ -510,9 +510,13 @@ class AMGPlayKit : LinearLayout, AMGPlayerInterface {
         player?.play()
     }
 
-    fun loadMedia(serverUrl: String, entryID: String, ks: String? = null, title: String? = null, mediaType: AMGMediaType = AMGMediaType.VOD) {
+    fun loadMedia(serverUrl: String, entryID: String, ks: String? = null, title: String? = null, mediaType: AMGMediaType = AMGMediaType.VOD, startPosition: Long = -1) {
         if (partnerId > 0) {
-            loadMedia(MediaItem(serverUrl, partnerId, entryID, ks, title, mediaType), mediaType)
+            if (startPosition >= 0) {
+                loadMedia(MediaItem(serverUrl, partnerId, entryID, ks, title, mediaType), mediaType, startPosition)
+            } else {
+                loadMedia(MediaItem(serverUrl, partnerId, entryID, ks, title, mediaType), mediaType)
+            }
         } else {
             print("Please provide a PartnerID with the request, add a default with 'addPartnerID(partnerID:Int)' or set a default in the initialiser")
         }
@@ -722,6 +726,10 @@ class AMGPlayKit : LinearLayout, AMGPlayerInterface {
             setBitrate(it)
         }
         startControlVisibilityTimer()
+    }
+
+    fun setMaximumBitrate(bitRate: Long){
+        player?.settings?.setABRSettings(ABRSettings().setMaxVideoBitrate(bitRate))
     }
 
     private fun bringControlsToForeground() {

--- a/streamamg-sdk-playkit/src/main/java/com/streamamg/amg_playkit/controls/AMGPlayKitStandardControl.kt
+++ b/streamamg-sdk-playkit/src/main/java/com/streamamg/amg_playkit/controls/AMGPlayKitStandardControl.kt
@@ -139,7 +139,7 @@ class AMGPlayKitStandardControl : LinearLayout, AMGControlInterface {
                 startTime.visibility = View.VISIBLE
         //        endTime.visibility = View.VISIBLE
             } else {
-                startTime.visibility = View.GONE
+                startTime.visibility = View.INVISIBLE
           //      endTime.visibility = View.GONE
             }
 
@@ -300,7 +300,7 @@ class AMGPlayKitStandardControl : LinearLayout, AMGControlInterface {
         spoilerFreeLeftView.setBackgroundResource(scrubBarLiveColour)
         spoilerFreeRightView.setBackgroundResource(scrubBarLiveColour)
         setSpoilerFree(spoilerFreeEnabled)
-        startTime.visibility = GONE
+        startTime.visibility = INVISIBLE
         liveButton.visibility = VISIBLE
         liveButton.setTextColor(ContextCompat.getColor(context, scrubBarLiveColour))
     }

--- a/streamamg-sdk-playkit/src/main/java/com/streamamg/amg_playkit/playkitExtensions/AMGPlayKit+Bitrate.kt
+++ b/streamamg-sdk-playkit/src/main/java/com/streamamg/amg_playkit/playkitExtensions/AMGPlayKit+Bitrate.kt
@@ -1,9 +1,6 @@
 package com.streamamg.amg_playkit.playkitExtensions
 
 import android.util.Log
-import com.google.android.material.floatingactionbutton.FloatingActionButton
-import com.kaltura.playkit.player.ABRSettings
-import com.kaltura.playkit.player.LoadControlBuffers
 import com.streamamg.amg_playkit.AMGPlayKit
 import retrofit2.Call
 import retrofit2.Callback
@@ -56,15 +53,6 @@ internal fun AMGPlayKit.updateBitrateSelector() {
 
 
 class MediaContext (
-//    val isSiteRestricted: Boolean?,
-//    val isCountryRestricted: Boolean?,
-//    val isIpAddressRestricted: Boolean?,
-//    val isUserAgentRestricted: Boolean?,
-//    val previewLength: Long?,
-//    val isScheduledNow: Boolean?,
-//    val isAdmin: Boolean?,
-//    val streamerType:String?,
-//    val mediaProtocol:String?,
     val flavorAssets: List<FlavorAsset>?,
 ) {
 
@@ -77,27 +65,10 @@ class MediaContext (
     }
 }
 
-
 class FlavorAsset (
-//    val flavorParamsId: Int?,
     val width: Long?,
     val height: Long?,
     val bitrate: Long?,
-//    val frameRate: Int?,
-//    val isOriginal: Boolean?,
-//    val isWeb: Boolean?,
-//    val containerFormat: String?,
-//    val videoCodecId: String?,
-//    val status: Int?,
     val id: String?,
-    val entryId: String?,
-//    val partnerId: Int?,
-//    val version: Int?,
-//    val size: Long?,
-//    val tags: String?,
-//    val fileExt: String?,
-//    val createdAt: Long?,
-//    val updatedAt: Long?,
-//    val deletedAt: Long?,
-//    val description: String?
+    val entryId: String?
 )


### PR DESCRIPTION
SMD-368
- Added start position param to loadMedia public function
- Fixed bitrate selector icon position during live video
- Brought back setMaximumBitrate function passing Long param
- Removed unused FlavorAsset variables
- Updated readme docs
- Version 1.1.1